### PR TITLE
Fix test name valentyusb

### DIFF
--- a/cocotb_usb/host.py
+++ b/cocotb_usb/host.py
@@ -1,3 +1,4 @@
+import inspect
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer, ClockCycles
@@ -57,9 +58,9 @@ class UsbTest:
                                   clk_period=self.clock_period)
 
         # Set the signal "test_name" to match this test
-        import inspect
+        test_name = kwargs.get('test_name', inspect.stack()[2][3])
         tn = cocotb.binary.BinaryValue(value=None, n_bits=4096)
-        tn.buff = inspect.stack()[2][3]
+        tn.buff = test_name
         self.dut.test_name = tn
 
     @cocotb.coroutine

--- a/cocotb_usb/host_valenty.py
+++ b/cocotb_usb/host_valenty.py
@@ -10,7 +10,7 @@ from cocotb_usb.usb.packet import crc16
 from cocotb_usb.utils import grouper_tofit, parse_csr, assertEqual
 
 from cocotb_usb.host import UsbTest
-
+import inspect
 
 class UsbTestValenty(UsbTest):
     """Class for testing ValentyUSB IP core.
@@ -32,6 +32,7 @@ class UsbTestValenty(UsbTest):
         self.wb = WishboneMaster(dut, "wishbone", dut.clk12, timeout=20)
         self.csrs = dict()
         self.csrs = parse_csr(csr_file)
+        kwargs['test_name'] = inspect.stack()[2][3]
         super().__init__(dut, **kwargs)
 
     @cocotb.coroutine

--- a/cocotb_usb/host_valenty.py
+++ b/cocotb_usb/host_valenty.py
@@ -12,6 +12,7 @@ from cocotb_usb.utils import grouper_tofit, parse_csr, assertEqual
 from cocotb_usb.host import UsbTest
 import inspect
 
+
 class UsbTestValenty(UsbTest):
     """Class for testing ValentyUSB IP core.
     Includes functions to communicate and generate responses without a CPU,


### PR DESCRIPTION
This patchset fixes the `test_name` signal on valentyusb, where it's currently always showing up as `get_harness`.