### PR TITLE
Support CDC tests for valentyusb

### DIFF
--- a/cocotb_usb/harness.py
+++ b/cocotb_usb/harness.py
@@ -12,7 +12,8 @@ def get_harness(dut, **kwargs):
     '''
     if TARGET == 'valentyusb':
         dut_csrs = environ['DUT_CSRS']  # We want a KeyError if this is unset
-        harness = UsbTestValenty(dut, dut_csrs, **kwargs)
+        cdc = int(environ['TEST_CDC'])  # We want a KeyError if this is unset
+        harness = UsbTestValenty(dut, dut_csrs, cdc, **kwargs)
     else:  # No target matched
         harness = UsbTest(dut, **kwargs)  # base class
     return harness

--- a/cocotb_usb/host.py
+++ b/cocotb_usb/host.py
@@ -71,9 +71,9 @@ class UsbTest:
         self.dut.usb_d_n = 0
         self.address = 0
 
-        yield ClockCycles(self.dut.clk48_host, 10, rising=True)
+        yield ClockCycles(self.dut.clk48_host, 50, rising=True)
         self.dut.reset = 0
-        yield ClockCycles(self.dut.clk48_host, 10, rising=True)
+        yield ClockCycles(self.dut.clk48_host, 50, rising=True)
 
     @cocotb.coroutine
     def wait(self, time, units="us"):

--- a/cocotb_usb/host.py
+++ b/cocotb_usb/host.py
@@ -268,7 +268,7 @@ class UsbTest:
         actual = pp_packet(result)
         nak = pp_packet(wrap_packet(handshake_packet(PID.NAK)))
         if (actual == nak) and (expected != nak):
-            self.dut._log.warn("Got NAK, retry")
+            self.dut._log.warning("Got NAK, retry")
             yield Timer(self.RETRY_INTERVAL, 'us')
             return
         else:

--- a/cocotb_usb/host_valenty.py
+++ b/cocotb_usb/host_valenty.py
@@ -1,4 +1,5 @@
 import cocotb
+from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge
 from cocotb.result import TestFailure, ReturnValue
 from cocotb.utils import get_sim_time
@@ -26,15 +27,31 @@ class UsbTestValenty(UsbTest):
             share clock signal. If set to False, you must provide clk48_device
             clock in test.
     """
-    def __init__(self, dut, csr_file, **kwargs):
+    def __init__(self, dut, csr_file, cdc=False, **kwargs):
         # Litex imports
         from cocotb_usb.wishbone import WishboneMaster
 
-        self.wb = WishboneMaster(dut, "wishbone", dut.clk12, timeout=20)
+        # Define the sys clock, as well as a factor used to wait longer
+        # when running with a faster clock
+        if cdc:
+            self.clk_sys = dut.clk100
+            self.clk_factor = 9
+        else:
+            self.clk_sys = dut.clk12
+            self.clk_factor = 1
+
+        self.wb = WishboneMaster(dut, "wishbone", self.clk_sys, timeout=20)
         self.csrs = dict()
         self.csrs = parse_csr(csr_file)
         kwargs['test_name'] = inspect.stack()[2][3]
         super().__init__(dut, **kwargs)
+
+        if cdc:
+            self.dut._log.info("CDC is enabled")
+            self.clock_100_period = 10000
+            cocotb.fork(Clock(dut.clk100, self.clock_100_period, 'ps').start())
+        else:
+            self.dut._log.info("CDC is DISABLED")
 
     @cocotb.coroutine
     def reset(self):
@@ -97,15 +114,23 @@ class UsbTestValenty(UsbTest):
     def expect_setup(self, epaddr, expected_data):
         actual_data = []
         # wait for data to appear
-        for i in range(128):
+        for i in range(300 * self.clk_factor):
+            self.dut._log.debug("Interrupt loop {}".format(i))
+            status = yield self.read(self.csrs['usb_setup_ev_pending'])
+            have = status & 0x1
+            if have:
+                break
+            yield RisingEdge(self.clk_sys)
+
+        for i in range(128 * self.clk_factor):
             self.dut._log.debug("Prime loop {}".format(i))
             status = yield self.read(self.csrs['usb_setup_status'])
             have = status & 0x10
             if have:
                 break
-            yield RisingEdge(self.dut.clk12)
+            yield RisingEdge(self.clk_sys)
 
-        for i in range(48):
+        for i in range(48 * self.clk_factor):
             self.dut._log.debug("Read loop {}".format(i))
             status = yield self.read(self.csrs['usb_setup_status'])
             have = status & 0x10
@@ -113,7 +138,7 @@ class UsbTestValenty(UsbTest):
                 break
             v = yield self.read(self.csrs['usb_setup_data'])
             actual_data.append(v)
-            yield RisingEdge(self.dut.clk12)
+            yield RisingEdge(self.clk_sys)
 
         if len(actual_data) < 2:
             raise TestFailure("data was short (got {}, expected {})".format(
@@ -164,15 +189,24 @@ class UsbTestValenty(UsbTest):
     def expect_data(self, epaddr, expected_data, expected):
         actual_data = []
         # wait for data to appear
-        for i in range(128):
+
+        for i in range(1500 * self.clk_factor):
+            self.dut._log.debug("Interrupt loop {}".format(i))
+            status = yield self.read(self.csrs['usb_out_ev_pending'])
+            have = status & 0x1
+            if have:
+                break
+            yield RisingEdge(self.clk_sys)
+
+        for i in range(128 * self.clk_factor):
             self.dut._log.debug("Prime loop {}".format(i))
             status = yield self.read(self.csrs['usb_out_status'])
             have = status & (1 << 4)
             if have:
                 break
-            yield RisingEdge(self.dut.clk12)
+            yield RisingEdge(self.clk_sys)
 
-        for i in range(256):
+        for i in range(256 * self.clk_factor):
             self.dut._log.debug("Read loop {}".format(i))
             status = yield self.read(self.csrs['usb_out_status'])
             have = status & (1 << 4)
@@ -180,7 +214,7 @@ class UsbTestValenty(UsbTest):
                 break
             v = yield self.read(self.csrs['usb_out_data'])
             actual_data.append(v)
-            yield RisingEdge(self.dut.clk12)
+            yield RisingEdge(self.clk_sys)
 
         if expected == PID.ACK:
             if len(actual_data) < 2:
@@ -341,6 +375,8 @@ class UsbTestValenty(UsbTest):
         in_ev = yield self.read(self.csrs['usb_in_ev_pending'])
         yield self.write(self.csrs['usb_in_ev_pending'], in_ev)
         yield self.write(self.csrs['usb_in_ctrl'], 1 << 5)  # Reset IN buffer
+        yield RisingEdge(self.dut.clk12)
+        yield RisingEdge(self.dut.clk12)
 
         # Was the time limit honored?
         if get_sim_time("us") > self.request_deadline:
@@ -385,7 +421,7 @@ class UsbTestValenty(UsbTest):
             self.dut._log.info("data stage")
             yield self.transaction_data_in(addr, epaddr_in, descriptor_data)
 
-            # Give the signal two clock cycles
+            # Give the signal two slow clock cycles
             # to percolate through the event manager
             yield RisingEdge(self.dut.clk12)
             yield RisingEdge(self.dut.clk12)
@@ -399,6 +435,11 @@ class UsbTestValenty(UsbTest):
         out_ev = yield self.read(self.csrs['usb_out_ev_pending'])
         yield self.transaction_status_out(addr, epaddr_out)
         yield RisingEdge(self.dut.clk12)
+
+        yield RisingEdge(self.clk_sys) # more time to percolate the event through synchronizers
+        yield RisingEdge(self.clk_sys) # before clearing it
+        yield RisingEdge(self.clk_sys) # this is for CDC implementations
+
         out_ev = yield self.read(self.csrs['usb_out_ev_pending'])
         yield self.write(self.csrs['usb_out_ctrl'], 0x20)  # Reset FIFO
         yield self.write(self.csrs['usb_out_ev_pending'], out_ev)


### PR DESCRIPTION
This patchset adds support for testing clock domain crossing on valentyusb. It checks the `TEST_CDC` parameter to decide whether to enable this functionality.